### PR TITLE
Get the trace name from trace

### DIFF
--- a/ui/plotlychartingkit/plotlysdk.runtime.js
+++ b/ui/plotlychartingkit/plotlysdk.runtime.js
@@ -238,7 +238,11 @@ function TWRuntimeChart(widget, cssClass) {
                 default:
                     trace.line.dash = 'solid';
             };
-            trace.name = properties['SeriesLabel' + series];
+            
+            if (properties['SeriesLabel' + series] !== undefined) {
+                trace.name = properties['SeriesLabel' + series];
+            }
+            
             trace.hoverinfo = 'none';
             if (properties['ShowTooltip' + series]) {
                 trace.hoverinfo = properties['TooltipFormat' + series];


### PR DESCRIPTION
The name is always getting from Series Label, this will avoid getting the trace name direct from data.